### PR TITLE
accept the alternative display data reply in QS2S

### DIFF
--- a/modules/devio.c
+++ b/modules/devio.c
@@ -52,6 +52,7 @@
 #define INTR_LENGTH 8
 
 #define QS2S_RESPONSE_CODE 0xff
+#define QS2S_DATA_RESPONSE_CODE 0x45 /* the display data reply on some mics */
 
 #define TIMEOUT 1000 /* one second per packet */
 #define BMREQUEST_TYPE_OUT 0x21
@@ -427,7 +428,14 @@ static int send_interrupt_with_rsp(libusb_device_handle *handle, byte_t *pck,
 
 static int qs2s_rsp_check(const byte_t *cmd, const byte_t *rsp)
 {
-    if (rsp[0] != QS2S_RESPONSE_CODE) {
+    if (rsp[0] == QS2S_DATA_RESPONSE_CODE) {
+        /* Such a reply carries no rsp[14], the command is echoed in rsp[1] */
+        if (rsp[1] != cmd[1]) {
+            fprintf(stderr, "Response command mismatch: %x instead of %x\n",
+                                                               rsp[1], cmd[1]);
+            return 2;
+        }
+    } else if (rsp[0] != QS2S_RESPONSE_CODE) {
         fprintf(stderr, "Response code mismatch: %x instead of %x\n", rsp[0],
                                                            QS2S_RESPONSE_CODE);
         return 1;


### PR DESCRIPTION
Hi! My QuadCast 2 S never lit up: the program exits right after start with

```
Response code mismatch: 45 instead of ff
```

and, since it happens on the first data packet of the display loop, no color is
ever sent. Here is what the mic actually replies (built with `make dev`, plus
a `print_packet(rsp, "Response:")` in `send_interrupt_with_rsp`):

```
Header display:
44 01 06 00 00 00 ...
Response:
FF 01 00 00 00 00 00 00 00 00 00 00 00 00 44 01     <- as expected

Data:
44 02 00 00 00 FF 00 00 ...
Response:
45 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00     <- 0x45, rsp[14] is empty
```

So the header keeps the documented form, while the display data packets get a
different one: the code is 0x45 and the command is echoed in `rsp[1]`, not in
`rsp[14]` (`rsp[2]` seems to be the index of the next expected packet). Over a
long run this is perfectly consistent, 9317 display cycles, 65219 packets, no
other reply shape:

| command | reply | count |
| --- | --- | --- |
| `44 01` (header) | `FF 01 ... 44 01` | 9317 |
| `44 02` (data) | `45 02 ...` | 55902 |

The patch takes that reply as valid and checks the echoed command in `rsp[1]`.

**This looks like a firmware revision difference, so the 0xff branch is left
first and untouched.** In #18 @omissis reported the mic working on 2026-03-30,
two days after the response checks were added in 4cf64b6, so on his device the
strict check clearly passes. His and mine are not the same revision:

| | controller `02b5` | mic `0d84` | data reply |
| --- | --- | --- | --- |
| @timbru31 in #18 (works) | 61.13 | 41.05 | presumably `ff` |
| mine (fails) | **61.12** | **41.03** | `45` |

Mine is the older firmware of the two. With the patch applied it works: the
solid mode sets the color and holds it for as long as the daemon runs. I have
not tested the other modes, the man page says they are not supported on this
model anyway.

The caveat is that I have exactly one device, so I cannot tell whether 0x45
belongs to a range of revisions or to something else entirely. If anybody else
with a 2S reads this, `quadcastrgb -v solid 00ff00` plus the revision from
`lsusb -v` would settle it. Happy to collect any other dumps you need, I still
have the mic and the capture setup.

Device details, in case they matter:

```
Bus 001 Device 010: ID 03f0:02b5 HP, Inc HyperX QuadCast 2 S Controller
Bus 001 Device 011: ID 03f0:0d84 HP, Inc HyperX QuadCast 2 S
```

The patch is against `main`, but it also cherry-picks cleanly onto
`support-for-quadcast-2s` if you prefer to keep the 2S work there. Say the word
and I will retarget it instead of opening a second PR.

This may well be the same thing as #29, which has the `lsusb` output of a 0d84
but no description of the failure.
