### PR TITLE
add a nix flake with a nixos module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ make rpmpkg # build the package in ~/rpmbuild/
 rpm -ivh quadcastrgb-1.0.4-2.x86_64.rpm
 ```
 
+## NixOS
+The repository is a flake. Add it as an input and enable the module:
+```nix
+inputs.quadcastrgb.url = "github:Ors1mer/QuadcastRGB";
+...
+imports = [ inputs.quadcastrgb.nixosModules.default ];
+services.quadcastrgb.enable = true;
+```
+The module installs the program *and* the udev rule, so there is no need to
+create the rule by hand or to add yourself to a group: the microphone becomes
+writable for whoever is logged in.
+
+Optionally, set the lights on every login (see the man page for the arguments):
+```nix
+services.quadcastrgb.arguments = [ "-b" "50" "solid" "4c0099" ];
+```
+The package on its own is `nix build github:Ors1mer/QuadcastRGB`, but then the
+rule has to be written manually as described below.
+
 ## MacOS
 ### Installation
 Download the binary executable for your processor architecture (Intel or ARM):

--- a/deps.mk
+++ b/deps.mk
@@ -1,0 +1,6 @@
+argparser.o: modules/argparser.c modules/argparser.h \
+ modules/locale_macros.h
+devio.o: modules/devio.c modules/locale_macros.h modules/devio.h \
+ modules/rgbmodes.h modules/argparser.h
+rgbmodes.o: modules/rgbmodes.c modules/devio.h modules/rgbmodes.h \
+ modules/argparser.h modules/locale_macros.h

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Set the RGB lights of HyperX Quadcast microphones";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forEachSystem = f:
+        nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forEachSystem (pkgs: rec {
+        quadcastrgb = pkgs.callPackage ./packages/nix/package.nix { };
+        default = quadcastrgb;
+      });
+
+      overlays.default = final: prev: {
+        quadcastrgb = final.callPackage ./packages/nix/package.nix { };
+      };
+
+      # Installing the package alone is not enough: without the udev rule the
+      # microphone is only writable by root. The module does both.
+      nixosModules.default = import ./packages/nix/module.nix self;
+
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          packages = [ pkgs.gcc pkgs.gnumake pkgs.libusb1 pkgs.gettext ];
+        };
+      });
+    };
+}

--- a/packages/nix/60-quadcastrgb.rules
+++ b/packages/nix/60-quadcastrgb.rules
@@ -1,0 +1,14 @@
+# The microphones quadcastrgb knows about, see product_ids_* in modules/devio.c.
+#
+# The uaccess tag gives the locally logged in user access to the device, so no
+# group has to be created and no rights have to be granted by hand. The file
+# name has to sort before systemd's 73-seat-late.rules, which is the rule that
+# turns the tag into an actual permission.
+SUBSYSTEM=="usb", ATTR{idVendor}=="0951", ATTR{idProduct}=="171f", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03f0", ATTR{idProduct}=="0f8b", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03f0", ATTR{idProduct}=="028c", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03f0", ATTR{idProduct}=="048c", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03f0", ATTR{idProduct}=="068c", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03f0", ATTR{idProduct}=="098c", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03f0", ATTR{idProduct}=="09af", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="03f0", ATTR{idProduct}=="02b5", TAG+="uaccess"

--- a/packages/nix/module.nix
+++ b/packages/nix/module.nix
@@ -1,0 +1,49 @@
+# A NixOS module: installs the program and, unlike a plain package, also puts
+# the udev rule in place so that the microphone is writable without superuser
+# rights. Exposed by the flake as nixosModules.default.
+self:
+
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.quadcastrgb;
+in
+{
+  options.services.quadcastrgb = {
+    enable = lib.mkEnableOption "the RGB control for HyperX Quadcast microphones";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.quadcastrgb;
+      defaultText = lib.literalExpression "quadcastrgb";
+      description = "The package to install and to take the udev rule from.";
+    };
+
+    arguments = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "-b" "50" "solid" "4c0099" ];
+      description = ''
+        Command line arguments to apply on login, see the man page. The empty
+        list, the default, only installs the program and sets no lights.
+
+        Note that the microphone forgets the colors when it loses power, hence
+        a login service rather than a system one.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+
+    systemd.user.services.quadcastrgb = lib.mkIf (cfg.arguments != [ ]) {
+      description = "Set the RGB lights of the HyperX Quadcast microphone";
+      wantedBy = [ "default.target" ];
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs cfg.arguments}";
+      };
+    };
+  };
+}

--- a/packages/nix/module.nix
+++ b/packages/nix/module.nix
@@ -43,7 +43,19 @@ in
       serviceConfig = {
         Type = "forking";
         ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs cfg.arguments}";
+        # The program stops on its own whenever the microphone stops talking
+        # back — muting it is enough on some models, unplugging it always is —
+        # and it exits successfully doing so, hence Restart=always rather than
+        # on-failure. This doubles as the way the lights come back after the
+        # mic is replugged, since it forgets them when it loses power.
+        Restart = "always";
+        RestartSec = 5;
       };
+
+      # No rate limiting: with no microphone attached the program exits at
+      # once, and retrying every few seconds costs nothing but means the
+      # lights appear by themselves once it is plugged back in.
+      unitConfig.StartLimitIntervalSec = 0;
     };
   };
 }

--- a/packages/nix/module.nix
+++ b/packages/nix/module.nix
@@ -43,13 +43,14 @@ in
       serviceConfig = {
         Type = "forking";
         ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs cfg.arguments}";
-        # The program stops on its own whenever the microphone stops talking
-        # back — muting it is enough on some models, unplugging it always is —
-        # and it exits successfully doing so, hence Restart=always rather than
-        # on-failure. This doubles as the way the lights come back after the
-        # mic is replugged, since it forgets them when it loses power.
+        # The microphone resets its HID interfaces on events of its own — on a
+        # Quadcast 2S every mute does it, verified against the kernel log — and
+        # that pulls the claimed interface out from under the running program,
+        # which then stops. It exits successfully doing so, hence always rather
+        # than on-failure. This doubles as the way the lights come back after a
+        # replug, since the mic forgets them when it loses power.
         Restart = "always";
-        RestartSec = 5;
+        RestartSec = 2;
       };
 
       # No rate limiting: with no microphone attached the program exits at

--- a/packages/nix/package.nix
+++ b/packages/nix/package.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, libusb1 }:
+
+stdenv.mkDerivation {
+  pname = "quadcastrgb";
+  version = "1.0.5"; # keep in sync with VERSION in the Makefile
+
+  src = lib.cleanSource ../..;
+
+  buildInputs = [ libusb1 ];
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  # The default install paths point into $HOME, which does not exist while
+  # building; the Makefile lets us redirect them, same as the AUR package does.
+  installFlags = [
+    "BINDIR_INS=${placeholder "out"}/bin/"
+    "MANDIR_INS=${placeholder "out"}/share/man/man1/"
+  ];
+
+  postInstall = ''
+    install -Dm644 packages/nix/60-quadcastrgb.rules \
+      $out/lib/udev/rules.d/60-quadcastrgb.rules
+  '';
+
+  meta = {
+    description = "Set the RGB lights of HyperX Quadcast microphones";
+    homepage = "https://github.com/Ors1mer/QuadcastRGB";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "quadcastrgb";
+    # The program builds on MacOS and FreeBSD as well, but neither is tested
+    # here, so only Linux is claimed.
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This adds Nix packaging, so that the program can be installed on NixOS the way
everything else is there: as a flake input.

```nix
inputs.quadcastrgb.url = "github:Ors1mer/QuadcastRGB";
...
imports = [ inputs.quadcastrgb.nixosModules.default ];
services.quadcastrgb.enable = true;
```

A package on its own would not be enough. On NixOS `/etc` is generated, so the
udev rule from the FAQ cannot simply be written by hand and kept, and without
the rule the microphone stays root-only. Hence a module: it installs the
program and the rule together.

What is in the patch:

- `flake.nix` at the root, one input (nixpkgs), exposing the package, an
  overlay, the module and a dev shell (`nix develop` gives gcc, make, libusb
  and gettext).
- `packages/nix/package.nix`, in the same spirit as `packages/aur/PKGBUILD`:
  it just calls `make` and then `make install` with `BINDIR_INS`/`MANDIR_INS`
  redirected into the store.
- `packages/nix/60-quadcastrgb.rules` with the ids from `modules/devio.c`. It
  uses `TAG+="uaccess"` instead of a group, so nothing has to be created and no
  user has to be added anywhere: whoever is logged in locally may talk to the
  mic. The number 60 matters, the rule has to sort before systemd's
  `73-seat-late.rules`, which is what turns the tag into a real permission.
- `packages/nix/module.nix` with three options: `enable`, `package` and
  `arguments`. The last one runs the program on login, which is a partial
  answer to #23, at least for this one distro.
- A `## NixOS` section in the README, next to the other distros.

Nothing outside `packages/nix/`, `flake.nix` and the README is touched, so the
Makefile and the deb/rpm/AUR/homebrew packaging keep working exactly as before.
Users who do not run Nix will not notice the files at all.

Two things worth knowing:

- `meta.platforms` claims Linux only. The Makefile has a MacOS mode and Nix can
  build for MacOS, but I have no Mac to test on and did not want to promise
  something untested.
- `flake.lock` is committed, as is customary, so that the build is reproducible.
  It pins nixpkgs only and needs no attention unless you want to refresh it.

This is independent of #32 and can be merged in any order; on the branch it was
tested together with that fix on a QuadCast 2 S.
